### PR TITLE
Fix/#54 fullscreen youtube

### DIFF
--- a/client/src/components/common/FullScreenMode.tsx
+++ b/client/src/components/common/FullScreenMode.tsx
@@ -33,6 +33,7 @@ const FullScreenBlock = styled.div<FullScreenProps>`
   }
   
   > div#themed {
+    position: relative;
     height: 100%;
     overflow-y: scroll;
     box-sizing: border-box;
@@ -91,6 +92,14 @@ const FullScreenBlock = styled.div<FullScreenProps>`
     
     iframe.youtube {
       flex: 1;
+      
+      &:only-child {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+      }
     }
     
     ${({slideTheme}) => applyTheme(slideTheme)}

--- a/client/src/components/markdown/extensions/Youtube.tsx
+++ b/client/src/components/markdown/extensions/Youtube.tsx
@@ -17,7 +17,7 @@ const Youtube: React.FC<IProps> = ({code = ""}) => {
       height="315"
       src={`https://www.youtube.com/embed/${id}`} frameBorder="0"
       allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-      allowFullScreen/> : null;
+    /> : null;
 };
 
 export default Youtube;


### PR DESCRIPTION
- Youtube `iframe`의 fullscreenbutton disable
- `iframe`이 혼자 있을 때 화면을 꽉 채우도록 css 수정

resolves #54 