### PR TITLE
Fix/#171 slide state management

### DIFF
--- a/client/src/components/common/SlidesLayout.tsx
+++ b/client/src/components/common/SlidesLayout.tsx
@@ -31,7 +31,7 @@ const SlidesLayout: React.FC<IProps> = ({getAllSlides, slidesCnt, title}) => {
         setSlides(res.data.slides);
         setTotalPage(res.data.totalPage);
       });
-  }, [page, totalPage]);
+  }, []);
 
   const onClickPage = (e: React.MouseEvent<HTMLDivElement>) => {
     const page = parseInt(e.currentTarget.getAttribute("data-page")!);

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -195,7 +195,7 @@ const Editor: React.FC = () => {
     try {
       id && await slideApi.delete(id);
       googleAnalyticsEvent("슬라이드", `#${id} 삭제 완료`);
-      history.push("/archive");
+      history.push("/me");
     } catch (error) {
       googleAnalyticsException(`슬라이드 #${id} 삭제 실패`);
     }

--- a/client/src/store/atoms.ts
+++ b/client/src/store/atoms.ts
@@ -1,33 +1,7 @@
 import {atom, selector} from "recoil";
-import {AxiosResponse} from "axios";
-import slideApi, {SlideResponses} from "../api/slide";
 import {User} from "../pages/Me";
 import usersApi from "../api/user";
 import {Toast} from "../domains/constants";
-import {googleAnalyticsException} from "../utils/googleAnalytics";
-
-export const getAllSlidesQuery = selector({
-  key: "getAllSlidesQuery",
-  get: async () => {
-    try {
-      const response: AxiosResponse<SlideResponses> = await slideApi.getAll({page: 0, size: 5});
-
-      return response.data.slides;
-    } catch (error) {
-      googleAnalyticsException("슬라이드 목록 조회 API 호출 실패");
-      throw error;
-    }
-  },
-});
-
-export const getPublicSlidesQuery = selector({
-  key: "getPublicSlidesQuery",
-  get: async () => {
-    const response: AxiosResponse<SlideResponses> = await slideApi.getPublic({page: 0, size: 5});
-
-    return response.data.slides;
-  },
-});
 
 export const userInfoTrigger = atom<number>({
   key: "userInfoTrigger",


### PR DESCRIPTION
resolves #171 

이미 로운이 페이지네이션 작업때 해 놔서...
리코일로 바꿔서 api호출 횟수를 줄이려고 했더니 서버 api 구조가 바껴서 불가능해졌네요 😭
현 상황에서 슬라이드를 굳이 리코일로 관리해서 얻는 이점이 없는 것 같아서 냅뒀습니다.
totalPage 의존성만 없애서 처음 렌더링 될 때 2번 호출 되는 부분만 고쳤습니다.